### PR TITLE
Revert "Bump vertx-dependencies from 3.5.4.redhat-00002 to 3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <vertx.version>3.6.0</vertx.version>
+    <vertx.version>3.5.4.redhat-00002</vertx.version>
     <infinispan.version>8.5.3.Final-redhat-00002</infinispan.version>
     <vertx.verticle>io.openshift.vertx.cache.CacheVerticle</vertx.verticle>
 


### PR DESCRIPTION
Reverts openshiftio-vertx-boosters/vertx-cache-booster-redhat#26